### PR TITLE
沈 chen2 -> shen3

### DIFF
--- a/lib/ruby-pinyin/Mandarin.dat
+++ b/lib/ruby-pinyin/Mandarin.dat
@@ -13570,7 +13570,7 @@
 6C85 yuan2 yuán
 6C86 hang4 hàng
 6C87 yan3 yǎn
-6C88 chen2 chén
+6C88 shen3 shěn
 6C89 chen2 chén
 6C8A dan4 dàn
 6C8B you2 yóu


### PR DESCRIPTION
沈在现代汉语中一般都发 shen3，在 gem 中发音 chen2 ，造成了一些不便。

本次提交修复了这个“问题”
