### PR TITLE
attempt fix of https://github.com/janx/ruby-pinyin/issues/18

### DIFF
--- a/lib/ruby-pinyin/backend/mmseg.rb
+++ b/lib/ruby-pinyin/backend/mmseg.rb
@@ -22,6 +22,11 @@ module PinYin
         base = @simple.romanize(str, tone, include_punctuations)
         patch = words.map {|w| format(w, tone) }.flatten
 
+        if base.size != patch.size
+          base.compact!
+          patch.compact!
+        end
+
         apply base, patch
       end
 

--- a/test/pinyin_test.rb
+++ b/test/pinyin_test.rb
@@ -17,6 +17,15 @@ class PinYinTest < Minitest::Test
     assert_equal ['jie', 'cao'], PinYin.of_string('节操')
   end
 
+  def test_mixed_in_random_garbage_characters
+    assert_equal ['jia', 'yi'], PinYin.of_string('×甲乙')
+    assert_equal ['jia', 'yi'], PinYin.of_string('甲×乙')
+    assert_equal ['jia', 'yi'], PinYin.of_string('甲乙×')
+    assert_equal ['jia', 'yi'], PinYin.of_string('×甲×乙')
+    assert_equal ['jia', 'yi'], PinYin.of_string('×甲×乙×')
+    assert_equal ['jia', 'yi', 'jia', 'yi'], PinYin.of_string('×甲×乙××甲×乙×')
+  end
+
   def test_get_pinyin_of_chinese_string_with_tone
     assert_equal ['jie2', 'cao1'], PinYin.of_string('节操', true)
   end


### PR DESCRIPTION
This is one way to fix #18 but not very pretty IMHO

the bug occurs when you `apply base, patch` while `base.size != patch.size`

`apply` expects same-length array arguments, but I don't see that `@simple.romanize` and `MMSeg#segment` will guarantee that... So maybe after the `compact!` if the length is still not equal we'd throw an exception on that?

Or better we refactor the code a little bit