### PR TITLE
Punctuation#punctuations: prevent race-condition

### DIFF
--- a/lib/ruby-pinyin/punctuation.rb
+++ b/lib/ruby-pinyin/punctuation.rb
@@ -24,19 +24,17 @@ module PinYin
       end
 
       def punctuations
-        return @punctuations if @punctuations
-
-        @punctuations = {}
-        src = File.expand_path('../data/Punctuations.dat', __FILE__)
-        load_from src 
-
-        @punctuations
+        @punctuations ||=
+          {}.tap do |punctuations|
+            src = File.expand_path('data/Punctuations.dat', __dir__)
+            load_from punctuations, src
+          end
       end
 
-      def load_from(file)
+      def load_from(punctuations, file)
         File.readlines(file).map do |line|
           from, to = line.split(/\s+/)
-          @punctuations[from] = to
+          punctuations[from] = to
         end
       end
 


### PR DESCRIPTION
您好，我在生产服务器上发现偶尔会出现错误: 

```
RegexpError: empty char-class: /([]+)$/ (Most recent call first)
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin/punctuation.rb line 10 in initialize
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin/punctuation.rb line 10 in new
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin/punctuation.rb line 10 in regexp
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin/backend/mmseg.rb line 99 in block in apply
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin/backend/mmseg.rb line 96 in each
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin/backend/mmseg.rb line 96 in each_with_index
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin/backend/mmseg.rb line 96 in apply
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin/backend/mmseg.rb line 30 in romanize
File /rails/vendor/bundle/ruby/3.0.0/gems/ruby-pinyin-0.5.0/lib/ruby-pinyin.rb line 12 in romanize
```

发现在多线程环境里(sidekiq / puma)，第一次加载 `@punctuations` 变量时会有 race-condition，一个简单的重现该错误的代码：

```
require 'bundler/setup'
require 'ruby-pinyin'

loop do
  1000.times.map do
    Thread.new do
      puts PinYin.of_string('甲乙丙丁').join(',')
    end
  end.each(&:join)
end
```